### PR TITLE
Add HTML gaming news page and dotenv configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Gaming News API
+
+A small Flask application that fetches the latest gaming news articles from [NewsAPI](https://newsapi.org/).
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `.env` file in the project root and add your API key:
+   ```bash
+   NEWS_API_KEY=your_api_key_here
+   ```
+   You can obtain a free key by creating an account at [NewsAPI](https://newsapi.org/).
+
+## Run
+
+```bash
+python main.py
+```
+
+The server will start on `http://localhost:5000`.
+
+## Usage
+
+- **JSON API:** `GET /api/gaming-news` returns the latest articles as JSON.
+- **HTML page:** Visit `http://localhost:5000/gaming-news` to view articles formatted for the browser.
+- **Health check:** `GET /api/health` confirms the API status.
+
+## Environment
+
+This application uses `python-dotenv` to load environment variables, making it easy to run in environments like Termux. Ensure the `.env` file or the `NEWS_API_KEY` environment variable is set before starting the server.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "gunicorn>=23.0.0",
     "psycopg2-binary>=2.9.10",
     "requests>=2.32.3",
+    "python-dotenv>=1.0.1",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ Jinja2==3.1.6
 MarkupSafe==3.0.2
 Werkzeug==3.1.3
 requests==2.32.3
+
+python-dotenv==1.0.1

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Error</title>
+    <link href="https://cdn.replit.com/agent/bootstrap-agent-dark-theme.min.css" rel="stylesheet">
+</head>
+<body>
+    <div class="container py-5">
+        <h1 class="text-danger mb-4">Error</h1>
+        <p>{{ message }}</p>
+        <a href="/" class="btn btn-primary mt-3">Go Home</a>
+    </div>
+</body>
+</html>

--- a/templates/gaming_news.html
+++ b/templates/gaming_news.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gaming News</title>
+    <link href="https://cdn.replit.com/agent/bootstrap-agent-dark-theme.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+</head>
+<body>
+    <div class="container py-4">
+        <h1 class="mb-4"><i class="fas fa-gamepad text-success me-2"></i>Latest Gaming News</h1>
+        {% if articles %}
+            {% for article in articles %}
+                <div class="card mb-3">
+                    <div class="card-body">
+                        <h5 class="card-title"><a href="{{ article.url }}" class="text-decoration-none">{{ article.title }}</a></h5>
+                        <p class="card-text">{{ article.description }}</p>
+                        <p class="card-text"><small class="text-muted">{{ article.source }} - {{ article.publishedAt }}</small></p>
+                    </div>
+                </div>
+            {% endfor %}
+        {% else %}
+            <p>No articles found.</p>
+        {% endif %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Load environment variables using `python-dotenv` and centralize news fetching with date formatting
- Add browser-friendly `/gaming-news` page with Bootstrap styling
- Document setup and usage, including new dependencies

## Testing
- `python -m py_compile app.py main.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6c0d22718832c96dc26fe4b7920c2