### PR TITLE
Display gaming news articles with images in a news-style layout

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,7 @@ def _fetch_gaming_news():
             "title": a.get("title"),
             "description": a.get("description"),
             "url": a.get("url"),
+            "image": a.get("urlToImage"),
             "publishedAt": format_date(a.get("publishedAt")),
             "source": (a.get("source") or {}).get("name"),
         }

--- a/templates/gaming_news.html
+++ b/templates/gaming_news.html
@@ -6,23 +6,41 @@
     <title>Gaming News</title>
     <link href="https://cdn.replit.com/agent/bootstrap-agent-dark-theme.min.css" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <style>
+        .news-card img {
+            object-fit: cover;
+            height: 180px;
+        }
+    </style>
 </head>
 <body>
     <div class="container py-4">
         <h1 class="mb-4"><i class="fas fa-gamepad text-success me-2"></i>Latest Gaming News</h1>
         {% if articles %}
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4">
             {% for article in articles %}
-                <div class="card mb-3">
-                    <div class="card-body">
-                        <h5 class="card-title"><a href="{{ article.url }}" class="text-decoration-none">{{ article.title }}</a></h5>
+            <div class="col">
+                <div class="card h-100 news-card">
+                    {% if article.image %}
+                    <img src="{{ article.image }}" class="card-img-top" alt="article image">
+                    {% else %}
+                    <img src="https://via.placeholder.com/300x180?text=No+Image" class="card-img-top" alt="no image available">
+                    {% endif %}
+                    <div class="card-body d-flex flex-column">
+                        <h5 class="card-title"><a href="{{ article.url }}" class="text-decoration-none" target="_blank">{{ article.title }}</a></h5>
                         <p class="card-text">{{ article.description }}</p>
-                        <p class="card-text"><small class="text-muted">{{ article.source }} - {{ article.publishedAt }}</small></p>
+                    </div>
+                    <div class="card-footer">
+                        <small class="text-muted">{{ article.source }} - {{ article.publishedAt }}</small>
                     </div>
                 </div>
+            </div>
             {% endfor %}
+        </div>
         {% else %}
-            <p>No articles found.</p>
+        <p>No articles found.</p>
         {% endif %}
     </div>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- Include article image URLs when fetching gaming news
- Present gaming news with responsive Bootstrap cards and placeholders

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c99a1ad8832caed0bab0800005f6