### PR TITLE
Add link to gaming news page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,17 +19,23 @@
                             Flask REST API
                         </h1>
                         <p class="lead">Simple and clean REST API with comprehensive documentation</p>
-                        <div class="d-flex justify-content-center gap-3">
-                            <span class="badge bg-success fs-6">
-                                <i class="fas fa-check-circle me-1"></i>
-                                API Status: Online
-                            </span>
-                            <span class="badge bg-info fs-6">
-                                <i class="fas fa-code-branch me-1"></i>
-                                Version: 1.0.0
-                            </span>
-                        </div>
-                    </div>
+                          <div class="d-flex justify-content-center gap-3">
+                              <span class="badge bg-success fs-6">
+                                  <i class="fas fa-check-circle me-1"></i>
+                                  API Status: Online
+                              </span>
+                              <span class="badge bg-info fs-6">
+                                  <i class="fas fa-code-branch me-1"></i>
+                                  Version: 1.0.0
+                              </span>
+                          </div>
+                          <div class="mt-4">
+                              <a href="/gaming-news" class="btn btn-outline-info">
+                                  <i class="fas fa-newspaper me-2"></i>
+                                  Gaming News
+                              </a>
+                          </div>
+                      </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- link to new /gaming-news page from homepage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be245197a4832ca930c54c504f7ec0