### PR TITLE
Add link to gaming news page

### DIFF
--- a/app.py
+++ b/app.py
@@ -22,11 +22,17 @@ CORS(app)
 NEWS_API_URL = "https://newsapi.org/v2/everything"
 
 
-def _fetch_gaming_news():
-    """Fetch gaming news articles from the external API"""
-    api_key = os.environ.get("NEWS_API_KEY")
+def _get_news_api_key() -> str:
+    """Retrieve the News API key from environment variables"""
+    api_key = os.environ.get("NEWS_API_KEY") or os.environ.get("VERCEL_NEWS_API_KEY")
     if not api_key:
         raise RuntimeError("NEWS_API_KEY environment variable is not set")
+    return api_key
+
+
+def _fetch_gaming_news():
+    """Fetch gaming news articles from the external API"""
+    api_key = _get_news_api_key()
 
     params = {
         "q": "gaming",

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,17 +19,23 @@
                             Flask REST API
                         </h1>
                         <p class="lead">Simple and clean REST API with comprehensive documentation</p>
-                        <div class="d-flex justify-content-center gap-3">
-                            <span class="badge bg-success fs-6">
-                                <i class="fas fa-check-circle me-1"></i>
-                                API Status: Online
-                            </span>
-                            <span class="badge bg-info fs-6">
-                                <i class="fas fa-code-branch me-1"></i>
-                                Version: 1.0.0
-                            </span>
-                        </div>
-                    </div>
+                          <div class="d-flex justify-content-center gap-3">
+                              <span class="badge bg-success fs-6">
+                                  <i class="fas fa-check-circle me-1"></i>
+                                  API Status: Online
+                              </span>
+                              <span class="badge bg-info fs-6">
+                                  <i class="fas fa-code-branch me-1"></i>
+                                  Version: 1.0.0
+                              </span>
+                          </div>
+                          <div class="mt-4">
+                              <a href="/gaming-news" class="btn btn-outline-info">
+                                  <i class="fas fa-newspaper me-2"></i>
+                                  Gaming News
+                              </a>
+                          </div>
+                      </div>
                 </div>
             </div>
         </div>

--- a/vercel.json
+++ b/vercel.json
@@ -4,8 +4,5 @@
   ],
   "routes": [
     { "src": "/(.*)", "dest": "main.py" }
-  ],
-  "env": {
-    "NEWS_API_KEY": "@news-api-key"
-  }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,8 @@
   ],
   "routes": [
     { "src": "/(.*)", "dest": "main.py" }
-  ]
+  ],
+  "env": {
+    "NEWS_API_KEY": "@news-api-key"
+  }
 }


### PR DESCRIPTION
## Summary
- link to new /gaming-news page from homepage
- read NEWS_API_KEY or VERCEL_NEWS_API_KEY to avoid missing configuration
- configure Vercel to forward NEWS_API_KEY secret

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be245197a4832ca930c54c504f7ec0