### PR TITLE
Use Vercel environment for NEWS_API_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The server will start on `http://localhost:5000`.
 
 ## Environment
 
-This application uses `python-dotenv` to load environment variables, making it easy to run in environments like Termux. Ensure the `.env` file or the `NEWS_API_KEY` environment variable is set before starting the server.
+This application loads `NEWS_API_KEY` from the environment at runtime. For local development, values from a `.env` file are used if the variable is not already defined. On platforms like Vercel, simply define `NEWS_API_KEY` in your project settings; no `.env` file is required.
 
 ## Deploy to Vercel
 

--- a/app.py
+++ b/app.py
@@ -6,8 +6,6 @@ from flask_cors import CORS
 from dotenv import load_dotenv
 import requests
 
-load_dotenv()
-
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 
@@ -25,6 +23,9 @@ NEWS_API_URL = "https://newsapi.org/v2/everything"
 def _get_news_api_key() -> str:
     """Retrieve the News API key from environment variables"""
     api_key = os.environ.get("NEWS_API_KEY")
+    if not api_key:
+        load_dotenv()
+        api_key = os.environ.get("NEWS_API_KEY")
     if not api_key:
         raise RuntimeError("NEWS_API_KEY environment variable is not set")
     return api_key


### PR DESCRIPTION
## Summary
- Lazily load NEWS_API_KEY from the environment, falling back to `.env` only if needed
- Document that NEWS_API_KEY can be supplied via Vercel environment variables

## Testing
- `python -m py_compile app.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68be649c20e4832c8c2a0daa1988a350