### PR TITLE
Add debug env endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The server will start on `http://localhost:5000`.
 - **JSON API:** `GET /api/gaming-news` returns the latest articles as JSON.
 - **HTML page:** Visit `http://localhost:5000/gaming-news` to view articles formatted for the browser.
 - **Health check:** `GET /api/health` confirms the API status.
+- **Debug environment:** `GET /api/debug-env` shows the value of the `CODEZ` environment variable.
 
 ## Environment
 

--- a/app.py
+++ b/app.py
@@ -162,6 +162,13 @@ def api_info():
     })
 
 
+@app.route('/api/debug-env', methods=['GET'])
+def debug_env():
+    """Expose selected environment variables for debugging"""
+    codez = os.environ.get("CODEZ")
+    return jsonify({"CODEZ": codez})
+
+
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5000, debug=True)
 


### PR DESCRIPTION
## Summary
- add `/api/debug-env` to reveal `CODEZ` env var for debugging
- document debug endpoint in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beb31baac4832c82d31daa9b2eaafc