### PR TITLE
Add debug env endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ A small Flask application that fetches the latest gaming news articles from [New
    ```bash
    pip install -r requirements.txt
    ```
-2. Create a `.env` file in the project root and add your API key:
+2. Create a `.env` file in the project root and add your API key and any debug variables:
    ```bash
    NEWS_API_KEY=your_api_key_here
+   CODEZ=example_value  # optional
    ```
    You can obtain a free key by creating an account at [NewsAPI](https://newsapi.org/).
 
@@ -27,10 +28,11 @@ The server will start on `http://localhost:5000`.
 - **JSON API:** `GET /api/gaming-news` returns the latest articles as JSON.
 - **HTML page:** Visit `http://localhost:5000/gaming-news` to view articles formatted for the browser.
 - **Health check:** `GET /api/health` confirms the API status.
+- **Debug environment:** `GET /api/debug-env` shows the value of the `CODEZ` environment variable.
 
 ## Environment
 
-This application loads `NEWS_API_KEY` from the environment at runtime. For local development, values from a `.env` file are used if the variable is not already defined. On platforms like Vercel, simply define `NEWS_API_KEY` in your project settings; no `.env` file is required.
+This application loads `NEWS_API_KEY` and other environment variables from the environment at runtime. For local development, values from a `.env` file are used if the variable is not already defined. On platforms like Vercel, simply define `NEWS_API_KEY` (and optionally `CODEZ`) in your project settings; no `.env` file is required.
 
 ## Deploy to Vercel
 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,9 @@ from flask_cors import CORS
 from dotenv import load_dotenv
 import requests
 
+# Load environment variables from a .env file if present
+load_dotenv()
+
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 
@@ -160,6 +163,13 @@ def api_info():
             "info": "/api/info",
         },
     })
+
+
+@app.route('/api/debug-env', methods=['GET'])
+def debug_env():
+    """Expose selected environment variables for debugging"""
+    codez = os.environ.get("CODEZ")
+    return jsonify({"CODEZ": codez})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `/api/debug-env` to reveal `CODEZ` env var for debugging
- document debug endpoint in README
- load environment variables from `.env` at startup so `CODEZ` is recognized

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beb31baac4832c82d31daa9b2eaafc